### PR TITLE
Introduce System Properties to configure ES host and port

### DIFF
--- a/batch/src/main/resources/reference.conf
+++ b/batch/src/main/resources/reference.conf
@@ -15,9 +15,11 @@ addressindex.spark.sql.shuffle.partitions=50
 addressindex.spark.yarn.executor.memoryOverhead=1024
 
 addressindex.elasticsearch.nodes="localhost"
+addressindex.elasticsearch.nodes=${?ONS_AI_DATA_ELASTICSEARCH_NODES}
 //9200 for internal cluster
 //addressindex.elasticsearch.port="9200"
 addressindex.elasticsearch.port="80"
+addressindex.elasticsearch.port=${?ONS_AI_DATA_ELASTICSEARCH_PORT}
 addressindex.elasticsearch.user="admin"
 addressindex.elasticsearch.pass="this should be overridden in local application.conf"
 addressindex.elasticsearch.indices.hybrid="hybrid-historical"


### PR DESCRIPTION
This change introduces two properties to configure the Elastic Search
host and port to which this data project attempt to connect to.

This allows changing the host and port of the ES instance at runtime
without having to make changes in the configuration files and rebuilding
the project.

The property names themselves align with the pattern seen for system
properties in configuration files of address-index-api (for example:
server/conf/application.conf)

Example of configuring the port from command line (running from the root
of address-index-data project):

JAVA_OPTS="-DONS_AI_DATA_ELASTICSEARCH_PORT=9200" \\
    sbt "project address-index-batch" \\
    "runMain uk.gov.ons.addressindex.Main --hybrid --mapping"

This passes in a custom value for the Elastic Search port that this
project connects to, changes the project to the sub-project
'address-index-batch' (since the main class resides in this sub-project)
and finally calls the 'runMain' task with the FQ class name and
parameters needed by the class