### PR TITLE
Update sbt-assembly plugin version from 0.14.3 to 0.14.5

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 logLevel := Level.Warn
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")


### PR DESCRIPTION
Without this a local build, with a clean ivy cache, fails after being
unable to resolve sbt-assembly v. 0.14.3