### PR TITLE
Secondary building sorting for Postcode Search (FWMT-1109)

### DIFF
--- a/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
@@ -51,10 +51,10 @@ For usage see below:
 //    postLoad(indexName)
 //  } else opts.printHelp()
 
-  val indexName = "sort1109test14_current"
+  val indexName = "sort1109test16_current"
   val url = s"http://$nodes:$port/$indexName"
-  postMapping(indexName, skinny = true)
-  saveHybridAddresses(historical = false, skinny = true, nisra = true)
+  postMapping(indexName, skinny = false)
+  saveHybridAddresses(historical = false, skinny = false, nisra = true)
 
   private def generateIndexName(historical: Boolean = true, skinny: Boolean = false, nisra: Boolean = false): String =
     AddressIndexFileReader.generateIndexNameFromFileName(historical, skinny, nisra)

--- a/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
@@ -37,24 +37,22 @@ For usage see below:
   val nodes = config.getString("addressindex.elasticsearch.nodes")
   val port = config.getString("addressindex.elasticsearch.port")
 
- //  each run of this application has a unique index name
-//  val indexName = generateIndexName(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
-//
-//  val url = s"http://$nodes:$port/$indexName"
-//
-//  if (!opts.help()) {
-//    AddressIndexFileReader.validateFileNames()
-//
-//    postMapping(indexName, skinny = opts.skinny())
-//    preLoad(indexName)
-//    saveHybridAddresses(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
-//    postLoad(indexName)
-//  } else opts.printHelp()
-
-  val indexName = "sort1109test16_current"
+  //  each run of this application has a unique index name
+  val indexName = generateIndexName(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
   val url = s"http://$nodes:$port/$indexName"
-  postMapping(indexName, skinny = false)
-  saveHybridAddresses(historical = false, skinny = false, nisra = true)
+
+  if (!opts.help()) {
+    AddressIndexFileReader.validateFileNames()
+    postMapping(indexName, skinny = opts.skinny())
+    preLoad(indexName)
+    saveHybridAddresses(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
+    postLoad(indexName)
+  } else opts.printHelp()
+
+  //  val indexName = generateIndexName(historical = false, skinny = true, nisra = true)
+  //  val url = s"http://$nodes:$port/$indexName"
+  //  postMapping(indexName, skinny = true)
+  //  saveHybridAddresses(historical = false, skinny = true, nisra = true)
 
   private def generateIndexName(historical: Boolean = true, skinny: Boolean = false, nisra: Boolean = false): String =
     AddressIndexFileReader.generateIndexNameFromFileName(historical, skinny, nisra)

--- a/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
@@ -38,23 +38,23 @@ For usage see below:
   val port = config.getString("addressindex.elasticsearch.port")
 
  //  each run of this application has a unique index name
-  val indexName = generateIndexName(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
-
-  val url = s"http://$nodes:$port/$indexName"
-
-  if (!opts.help()) {
-    AddressIndexFileReader.validateFileNames()
-
-    postMapping(indexName, skinny = opts.skinny())
-    preLoad(indexName)
-    saveHybridAddresses(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
-    postLoad(indexName)
-  } else opts.printHelp()
-
-//  val indexName = generateIndexName(historical = true, skinny = true, nisra = true)
+//  val indexName = generateIndexName(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
+//
 //  val url = s"http://$nodes:$port/$indexName"
-//  postMapping(indexName, skinny = true)
-//  saveHybridAddresses(historical = false, skinny = true, nisra = true)
+//
+//  if (!opts.help()) {
+//    AddressIndexFileReader.validateFileNames()
+//
+//    postMapping(indexName, skinny = opts.skinny())
+//    preLoad(indexName)
+//    saveHybridAddresses(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
+//    postLoad(indexName)
+//  } else opts.printHelp()
+
+  val indexName = "sort1109test14_current"
+  val url = s"http://$nodes:$port/$indexName"
+  postMapping(indexName, skinny = true)
+  saveHybridAddresses(historical = false, skinny = true, nisra = true)
 
   private def generateIndexName(historical: Boolean = true, skinny: Boolean = false, nisra: Boolean = false): String =
     AddressIndexFileReader.generateIndexNameFromFileName(historical, skinny, nisra)

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
@@ -269,10 +269,11 @@ abstract class EsDocument {
   }
 
   def addLeadingZeros(in: String): String = {
-    val tokens = in.split(" ")
+    val tokens = StringUtils.trimToEmpty(in).split(" ")
     val newTokens = tokens.map{tok =>
-      if (toInt(tok).isDefined) StringUtils.leftPad(tok,4,"0") else tok
+    val ntok = tok.filter(_.isDigit)
+    if (toInt(ntok).isDefined) tok.replace(ntok,StringUtils.leftPad(ntok,4,"0")) else tok
     }
-    return newTokens.mkString(" ")
+    newTokens.mkString(" ")
   }
 }

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
@@ -1,9 +1,11 @@
 package uk.gov.ons.addressindex.models
 
+import org.apache.commons.lang.StringUtils
 import org.apache.spark.sql.Row
 import uk.gov.ons.addressindex.utils.StringUtil.strToOpt
 
 import scala.io.{BufferedSource, Source}
+import scala.util.Try
 import scala.util.matching.Regex
 
 abstract class EsDocument {
@@ -256,5 +258,21 @@ abstract class EsDocument {
     // `Source.fromFile` needs an absolute path to the file, and current directory depends on where sbt was lauched
     // `getResource` may return null, that's why we wrap it into an `Option`
     Option(getClass.getResource(path)).map(Source.fromURL).getOrElse(Source.fromFile(currentDirectory + path))
+  }
+
+  def toShort(s: String): Option[Short] = {
+    Try(s.toShort).toOption
+  }
+
+  def toInt(s: String): Option[Int] = {
+    Try(s.toInt).toOption
+  }
+
+  def addLeadingZeros(in: String): String = {
+    val tokens = in.split(" ")
+    val newTokens = tokens.map{tok =>
+      if (toInt(tok).isDefined) StringUtils.leftPad(tok,4,"0") else tok
+    }
+    return newTokens.mkString(" ")
   }
 }

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocument.scala
@@ -80,7 +80,8 @@ object HybridAddressEsDocument extends EsDocument {
       normalize(row.getString(32)),
       normalizeTowns(row.getString(31)),
       row.getString(1)
-    )
+    ),
+    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + row.getString(11) + row.getString(20))
   )
 
   def rowToPaf(row: Row): Map[String, Any] = Map(

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocument.scala
@@ -81,7 +81,7 @@ object HybridAddressEsDocument extends EsDocument {
       normalizeTowns(row.getString(31)),
       row.getString(1)
     ),
-    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + row.getString(11) + row.getString(20))
+    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + " " + row.getString(11) + " " + row.getString(20))
   )
 
   def rowToPaf(row: Row): Map[String, Any] = Map(

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocument.scala
@@ -234,7 +234,8 @@ object HybridAddressNisraEsDocument extends EsDocument {
       "saoStartNumber" -> toShort(row.getString(9)).orNull,
       "saoStartSuffix" -> row.getString(11),
       "saoEndNumber" -> toShort(row.getString(10)).orNull,
-      "saoEndSuffix" -> row.getString(12)
+      "saoEndSuffix" -> row.getString(12),
+      "secondarySort" -> addLeadingZeros(row.getString(9) + row.getString(11) + " " + row.getString(13) + " " + row.getString(15))
     )
   }
 

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocument.scala
@@ -2,8 +2,6 @@ package uk.gov.ons.addressindex.models
 
 import org.apache.spark.sql.Row
 
-import scala.util.Try
-
 case class HybridAddressNisraEsDocument(uprn: Long,
                                         postcodeIn: String,
                                         postcodeOut: String,
@@ -83,7 +81,8 @@ object HybridAddressNisraEsDocument extends EsDocument {
       normalize(row.getString(32)),
       normalizeTowns(row.getString(31)),
       row.getString(1)
-    )
+    ),
+    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + row.getString(11) + row.getString(20))
   )
 
   def rowToPaf(row: Row): Map[String, Any] = Map(
@@ -174,13 +173,6 @@ object HybridAddressNisraEsDocument extends EsDocument {
     "source" -> row.getAs[String]("source")
   )
 
-  def toShort(s: String): Option[Short] = {
-    Try(s.toShort).toOption
-  }
-
-  def toInt(s: String): Option[Int] = {
-    Try(s.toInt).toOption
-  }
 
   def buildingNameExtra(s: String): String = {
     try {

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocument.scala
@@ -235,7 +235,7 @@ object HybridAddressNisraEsDocument extends EsDocument {
       "saoStartSuffix" -> row.getString(11),
       "saoEndNumber" -> toShort(row.getString(10)).orNull,
       "saoEndSuffix" -> row.getString(12),
-      "secondarySort" -> addLeadingZeros(row.getString(9) + row.getString(11) + " " + row.getString(13) + " " + row.getString(15))
+      "secondarySort" -> addLeadingZeros(Option(row.getString(9)).getOrElse("") + Option(row.getString(11)).getOrElse("") + " " + Option(row.getString(13)).getOrElse("") + " " + Option(row.getString(15)).getOrElse(""))
     )
   }
 

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocument.scala
@@ -82,7 +82,7 @@ object HybridAddressNisraEsDocument extends EsDocument {
       normalizeTowns(row.getString(31)),
       row.getString(1)
     ),
-    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + row.getString(11) + row.getString(20))
+    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + " " + row.getString(11) + " " + row.getString(20))
   )
 
   def rowToPaf(row: Row): Map[String, Any] = Map(

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyEsDocument.scala
@@ -55,7 +55,7 @@ object HybridAddressSkinnyEsDocument extends EsDocument {
       normalizeTowns(row.getString(31)),
       row.getString(1)
     ),
-    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + row.getString(11) + row.getString(20))
+    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + " " + row.getString(11) + " " + row.getString(20))
   )
 
   def rowToPaf(row: Row): Map[String, Any] = Map(

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyEsDocument.scala
@@ -54,7 +54,8 @@ object HybridAddressSkinnyEsDocument extends EsDocument {
       normalize(row.getString(32)),
       normalizeTowns(row.getString(31)),
       row.getString(1)
-    )
+    ),
+    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + row.getString(11) + row.getString(20))
   )
 
   def rowToPaf(row: Row): Map[String, Any] = Map(

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
@@ -1,7 +1,6 @@
 package uk.gov.ons.addressindex.models
 
 import org.apache.spark.sql.Row
-import uk.gov.ons.addressindex.models.HybridAddressNisraEsDocument.toShort
 
 case class HybridAddressSkinnyNisraEsDocument(uprn: Long,
                                               parentUprn: Long,
@@ -63,7 +62,8 @@ object HybridAddressSkinnyNisraEsDocument extends EsDocument {
       normalize(row.getString(32)),
       normalizeTowns(row.getString(31)),
       row.getString(1)
-    )
+    ),
+    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + row.getString(11) + row.getString(20))
   )
 
   def rowToPaf(row: Row): Map[String, Any] = Map(

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
@@ -63,7 +63,7 @@ object HybridAddressSkinnyNisraEsDocument extends EsDocument {
       normalizeTowns(row.getString(31)),
       row.getString(1)
     ),
-    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + row.getString(11) + row.getString(20))
+    "secondarySort" -> addLeadingZeros((if (row.isNullAt(23)) "" else row.getShort(23).toString) + row.getString(24) + " " + row.getString(11) + " " + row.getString(20))
   )
 
   def rowToPaf(row: Row): Map[String, Any] = Map(

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
@@ -145,7 +145,8 @@ object HybridAddressSkinnyNisraEsDocument extends EsDocument {
       "mixedNisra" -> nisraFormatted(0),
       "mixedAltNisra" -> nisraFormatted(1),
       "nisraAll" -> nisraFormatted(2),
-      "postcode" -> row.getString(22)
+      "postcode" -> row.getString(22),
+      "secondarySort" -> addLeadingZeros(row.getString(9) + row.getString(11) + " " + row.getString(13) + " " + row.getString(15))
     )
   }
 

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
@@ -146,7 +146,7 @@ object HybridAddressSkinnyNisraEsDocument extends EsDocument {
       "mixedAltNisra" -> nisraFormatted(1),
       "nisraAll" -> nisraFormatted(2),
       "postcode" -> row.getString(22),
-      "secondarySort" -> addLeadingZeros(row.getString(9) + row.getString(11) + " " + row.getString(13) + " " + row.getString(15))
+      "secondarySort" -> addLeadingZeros(Option(row.getString(9)).getOrElse("") + Option(row.getString(11)).getOrElse("") + " " + Option(row.getString(13)).getOrElse("") + " " + Option(row.getString(15)).getOrElse(""))
     )
   }
 

--- a/batch/src/main/scala/uk/gov/ons/addressindex/utils/Mappings.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/utils/Mappings.scala
@@ -832,6 +832,9 @@ object Mappings {
                               "mixedAltNisra": {
                                   "type": "text",
                                   "index": "false"
+                              },
+                              "secondarySort": {
+                                  "type": "keyword"
                               }
                           }
                       },
@@ -1446,6 +1449,9 @@ object Mappings {
                               "mixedAltNisra": {
                                   "type": "text",
                                   "index": "false"
+                              },
+                              "secondarySort": {
+                                  "type": "keyword"
                               }
                           }
                       },

--- a/batch/src/main/scala/uk/gov/ons/addressindex/utils/Mappings.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/utils/Mappings.scala
@@ -514,6 +514,9 @@ object Mappings {
                               "mixedNag": {
                                   "type": "text",
                                   "index": "false"
+                              },
+                              "secondarySort": {
+                                  "type": "keyword"
                               }
                           }
                       },
@@ -1305,6 +1308,9 @@ object Mappings {
                               "mixedNag": {
                                   "type": "text",
                                   "index": "false"
+                              },
+                              "secondarySort": {
+                                  "type": "keyword"
                               }
                           }
                       },

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocumentSpec.scala
@@ -111,6 +111,7 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
   val expectedNagLpiLastUpdateDate = new java.sql.Date(format.parse("2012-04-24").getTime)
   val expectedNagLpiEndDate = new java.sql.Date(format.parse("2018-01-11").getTime)
   val expectedNagMixed = "Something Else, 6473FF-6623JJ, The Building Name, A Training Centre, 56HH-7755OP And Another Street Descriptor, Locality Xyz, Town B, KL8 7HQ"
+  val expectedNagSecondarySort = "6623JJ SOMETHING ELSE THE BUILDING NAME"
 
   // Actual Nag Values
   val actualNagOrganisation = "SOMETHING ELSE"
@@ -227,7 +228,8 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
     "lpiStartDate" -> expectedNagLpiStartDate,
     "lpiLastUpdateDate" -> expectedNagLpiLastUpdateDate,
     "lpiEndDate" -> expectedNagLpiEndDate,
-    "mixedNag" -> expectedNagMixed
+    "mixedNag" -> expectedNagMixed,
+    "secondarySort" -> expectedNagSecondarySort
   )
 
   "Hybrid Address Elastic Search Document" should {

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocumentSpec.scala
@@ -512,6 +512,17 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
       result shouldBe "Acme Stats PLC, 6473FF-6623JJ, PO BOX 5678, A Training Centre, 56HH-7755OP And Another Street Descriptor, Locality Xyz, Town B, KL8 7HQ"
     }
 
+    "pad the secondary sort field (for postcode search) with leading zeros where needed" in {
+      // Given
+      val secondarySort = "FLAT 43A AARVARKS R US UNIT 75"
+
+      // When
+      val result = HybridAddressEsDocument.addLeadingZeros(secondarySort)
+
+      // Then
+      result shouldBe "FLAT 0043A AARVARKS R US UNIT 0075"
+    }
+
     "change uppercase nag address containing a hyphenated town name to mixed case" in {
       // Given
       val nagOrganisation = "ACME STATS PLC"

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocumentSpec.scala
@@ -111,6 +111,7 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedNagLpiLastUpdateDate = new java.sql.Date(format.parse("2012-04-24").getTime)
   val expectedNagLpiEndDate = new java.sql.Date(format.parse("2018-01-11").getTime)
   val expectedNagMixed = "Something Else, 6473FF-6623JJ, The Building Name, A Training Centre, 56HH-7755OP And Another Street Descriptor, Locality Xyz, Town B, KL8 7HQ"
+  val expectedNagSecondarySort = "6623JJ SOMETHING ELSE THE BUILDING NAME"
 
   // Actual Nag Values
   val actualNagOrganisation = "SOMETHING ELSE"
@@ -186,6 +187,7 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedNisraSaoStartSuffix = ""
   val expectedNisraSaoEndNumber = null
   val expectedNisraSaoEndSuffix = ""
+  val expectedNisraSecondarySort = "THE SUB BUILDING NAME AN ORGANISATION"
 
   // NISRA actual
   val actualNisraOrganisation = "AN ORGANISATION"
@@ -300,7 +302,8 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
     "lpiStartDate" -> expectedNagLpiStartDate,
     "lpiLastUpdateDate" -> expectedNagLpiLastUpdateDate,
     "lpiEndDate" -> expectedNagLpiEndDate,
-    "mixedNag" -> expectedNagMixed
+    "mixedNag" -> expectedNagMixed,
+    "secondarySort" -> expectedNagSecondarySort
   )
 
   val expectedNisra = Map[String,Any](
@@ -338,7 +341,8 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
     "saoStartNumber" -> expectedNisraSaoStartNumber,
     "saoStartSuffix" -> expectedNisraSaoStartSuffix,
     "saoEndNumber" -> expectedNisraSaoEndNumber,
-    "saoEndSuffix" -> expectedNisraSaoEndSuffix
+    "saoEndSuffix" -> expectedNisraSaoEndSuffix,
+    "secondarySort" -> expectedNisraSecondarySort
   )
 
   "Hybrid Address Elastic Search Document" should {

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyEsDocumentSpec.scala
@@ -64,6 +64,7 @@ class HybridAddressSkinnyEsDocumentSpec extends WordSpec with Matchers {
   val expectedNagLpiStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val expectedNagLpiEndDate = new java.sql.Date(format.parse("2018-01-11").getTime)
   val expectedNagMixed = "Something Else, 6473FF-6623JJ, The Building Name, A Training Centre, 56HH-7755OP And Another Street Descriptor, Locality Xyz, Town B, KL8 7HQ"
+  val expectedNagSecondarySort = "6623JJ SOMETHING ELSE THE BUILDING NAME"
 
   // Actual Nag values
   val actualNagOrganisation = "SOMETHING ELSE"
@@ -132,7 +133,8 @@ class HybridAddressSkinnyEsDocumentSpec extends WordSpec with Matchers {
     "language" -> expectedNagLanguage,
     "lpiStartDate" -> expectedNagLpiStartDate,
     "lpiEndDate" -> expectedNagLpiEndDate,
-    "mixedNag" -> expectedNagMixed
+    "mixedNag" -> expectedNagMixed,
+    "secondarySort" -> expectedNagSecondarySort
   )
 
   "Hybrid Address Elastic Search Document" should {

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocumentSpec.scala
@@ -64,6 +64,7 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedNagLpiStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val expectedNagLpiEndDate = new java.sql.Date(format.parse("2018-01-11").getTime)
   val expectedNagMixed = "Something Else, 6473FF-6623JJ, The Building Name, A Training Centre, 56HH-7755OP And Another Street Descriptor, Locality Xyz, Town B, KL8 7HQ"
+  val expectedNagSecondarySort = "6623JJ SOMETHING ELSE THE BUILDING NAME"
 
   // Actual Nag values
   val actualNagOrganisation = "SOMETHING ELSE"
@@ -118,6 +119,7 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A OFF HERE THOROUGHFARE ROAD AN ALTERNATIVE NAME A LOCALITY XYZ LITTLE TOWN AB1 7GH"
   val expectedNisraAddressStatus = "APPROVED"
   val expectedNisraClassificationCode = "DO_APART"
+  val expectedNisraSecondarySort = "0001 THE SUB BUILDING NAME AN ORGANISATION"
 
   // used by both expected and actual to avoid assertion error
   val nagLocation = Array(-2.3162985F, 4.00F)
@@ -148,7 +150,8 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
     "language" -> expectedNagLanguage,
     "lpiStartDate" -> expectedNagLpiStartDate,
     "lpiEndDate" -> expectedNagLpiEndDate,
-    "mixedNag" -> expectedNagMixed
+    "mixedNag" -> expectedNagMixed,
+    "secondarySort" -> expectedNagSecondarySort
   )
 
     // NISRA actual
@@ -201,7 +204,8 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
     "classificationCode" -> expectedNisraClassificationCode,
     "buildingNumber" -> expectedNisraBuildingNumber,
     "mixedAltNisra" -> expectedNisraAltMixed,
-    "nisraAll" -> expectedNisraAll
+    "nisraAll" -> expectedNisraAll,
+    "secondarySort" -> expectedNisraSecondarySort
   )
 
   "Hybrid Address Elastic Search Document" should {


### PR DESCRIPTION
To enable this facility, a new composite invisible sort field has been added to all the indexes. It pads any numbers in the field with leading zeros so that Flat 9A comes before Flat 11. Results look promising though further testing may necessitate a tweak to the composition of this field.

Note that this index is backward compatible with existing API code, but the corresponding PR for the API to enable this sorting requires an index built with the new field present. 