### PR TITLE
Elastic 7.3 Upgrade

### DIFF
--- a/batch/build.sbt
+++ b/batch/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-hive" % "2.3.2",
   "com.databricks" %% "spark-csv" % "1.5.0",
   "com.typesafe" % "config" % "1.3.3",
-  "org.elasticsearch" %% "elasticsearch-spark-20" % "7.1.1"  excludeAll ExclusionRule(organization = "javax.servlet"),
+  "org.elasticsearch" %% "elasticsearch-spark-20" % "7.3.1"  excludeAll ExclusionRule(organization = "javax.servlet"),
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,
   "org.rogach" %% "scallop" % "3.1.5",
   "org.scalaj" %% "scalaj-http" % "2.4.1",

--- a/batch/build.sbt
+++ b/batch/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-hive" % "2.3.2",
   "com.databricks" %% "spark-csv" % "1.5.0",
   "com.typesafe" % "config" % "1.3.3",
-  "org.elasticsearch" %% "elasticsearch-spark-20" % "5.6.14"  excludeAll ExclusionRule(organization = "javax.servlet"),
+  "org.elasticsearch" %% "elasticsearch-spark-20" % "7.1.1"  excludeAll ExclusionRule(organization = "javax.servlet"),
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,
   "org.rogach" %% "scallop" % "3.1.5",
   "org.scalaj" %% "scalaj-http" % "2.4.1",

--- a/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
@@ -38,21 +38,21 @@ For usage see below:
   val port = config.getString("addressindex.elasticsearch.port")
 
   //  each run of this application has a unique index name
-//  val indexName = generateIndexName(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
-//  val url = s"http://$nodes:$port/$indexName"
-//
-//  if (!opts.help()) {
-//    AddressIndexFileReader.validateFileNames()
-//    postMapping(indexName, skinny = opts.skinny())
-//    preLoad(indexName)
-//    saveHybridAddresses(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
-//    postLoad(indexName)
-//  } else opts.printHelp()
+  val indexName = generateIndexName(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
+  val url = s"http://$nodes:$port/$indexName"
 
-    val indexName = generateIndexName(historical = false, skinny = false, nisra = false)
-    val url = s"http://$nodes:$port/$indexName"
-    postMapping(indexName, skinny = false)
-    saveHybridAddresses(historical = false, skinny = false, nisra = false)
+  if (!opts.help()) {
+    AddressIndexFileReader.validateFileNames()
+    postMapping(indexName, skinny = opts.skinny())
+    preLoad(indexName)
+    saveHybridAddresses(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
+    postLoad(indexName)
+  } else opts.printHelp()
+
+//    val indexName = generateIndexName(historical = false, skinny = false, nisra = false)
+//    val url = s"http://$nodes:$port/$indexName"
+//    postMapping(indexName, skinny = false)
+//    saveHybridAddresses(historical = false, skinny = false, nisra = false)
 
   private def generateIndexName(historical: Boolean = true, skinny: Boolean = false, nisra: Boolean = false): String =
     AddressIndexFileReader.generateIndexNameFromFileName(historical, skinny, nisra)

--- a/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
@@ -38,21 +38,21 @@ For usage see below:
   val port = config.getString("addressindex.elasticsearch.port")
 
   //  each run of this application has a unique index name
-  val indexName = generateIndexName(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
-  val url = s"http://$nodes:$port/$indexName"
+//  val indexName = generateIndexName(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
+//  val url = s"http://$nodes:$port/$indexName"
+//
+//  if (!opts.help()) {
+//    AddressIndexFileReader.validateFileNames()
+//    postMapping(indexName, skinny = opts.skinny())
+//    preLoad(indexName)
+//    saveHybridAddresses(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
+//    postLoad(indexName)
+//  } else opts.printHelp()
 
-  if (!opts.help()) {
-    AddressIndexFileReader.validateFileNames()
-    postMapping(indexName, skinny = opts.skinny())
-    preLoad(indexName)
-    saveHybridAddresses(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
-    postLoad(indexName)
-  } else opts.printHelp()
-
-  //  val indexName = generateIndexName(historical = false, skinny = true, nisra = true)
-  //  val url = s"http://$nodes:$port/$indexName"
-  //  postMapping(indexName, skinny = true)
-  //  saveHybridAddresses(historical = false, skinny = true, nisra = true)
+    val indexName = generateIndexName(historical = false, skinny = false, nisra = false)
+    val url = s"http://$nodes:$port/$indexName"
+    postMapping(indexName, skinny = false)
+    saveHybridAddresses(historical = false, skinny = false, nisra = false)
 
   private def generateIndexName(historical: Boolean = true, skinny: Boolean = false, nisra: Boolean = false): String =
     AddressIndexFileReader.generateIndexNameFromFileName(historical, skinny, nisra)
@@ -95,6 +95,7 @@ For usage see below:
         } else {
           Mappings.hybrid
         })
+      .param("include_type_name", "true")
       .header("Content-type", "application/json")
       .asString
     if (response.code != 200) throw new Exception(s"Could not create mapping using PUT: code ${response.code} body ${response.body}")

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
@@ -210,7 +210,7 @@ abstract class EsDocument {
   /**
     * Convert external file into list
     *
-    * @param fileName
+    * @param fileName name of the file
     * @return
     */
   private def fileToList(fileName: String): Seq[String] = {
@@ -236,8 +236,8 @@ abstract class EsDocument {
   /**
     * Fetch file stream as buffered source
     *
-    * @param fileName
-    * @return
+    * @param fileName name of the file
+    * @return BufferedSource
     */
   def getResource(fileName: String): BufferedSource = {
     val path = "/" + fileName

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/NisraSchema.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/NisraSchema.scala
@@ -13,7 +13,6 @@ object NisraSchema {
     StructField("dependentThoroughfare", StringType, nullable = true),
     StructField("altThoroughfare", StringType, nullable = true),
     StructField("locality", StringType, nullable = true),
-  //  StructField("townland", StringType, nullable = true),
     StructField("townName", StringType, nullable = true),
     StructField("county", StringType, nullable = true),
     StructField("postcode", StringType, nullable = true),

--- a/batch/src/main/scala/uk/gov/ons/addressindex/utils/Mappings.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/utils/Mappings.scala
@@ -20,6 +20,7 @@ object Mappings {
                   "filter": {
                       "address_synonym_filter": {
                           "type": "synonym",
+                          "lenient": "true",
                           "synonyms": [
                               "ADJ, ADJACENT",
                               "ALY => ALLEY, ALY",
@@ -178,7 +179,6 @@ object Mappings {
                               "WLS => WELL, WLS",
                               "WLS => WELLS, WLS",
                               "XING => CROSSING, XING",
-      
                               "DEPT => DEPARTMENT, DEPT",
                               "OFC => OFFICE, OFC",
                               "LLC, LLP => LTD, LIMITED, LLC, LLP",
@@ -188,12 +188,10 @@ object Mappings {
                               "PLC, CCC => CO, COMPANY, PLC, CCC",
                               "CORP, CORPORATION",
                               "INC, INCOMPORATED, CORPORATION",
-      
                               "E => EAST, E",
                               "W => WEST, W",
                               "S => SOUTH, S",
                               "N => NORTH, N",
-      
                               "SAINT => ST, SAINT, SANT",
                               "SANT => ST, SAINT, SANT",
                               "0TH, ZEROTH, 0ED, SERO, SEROFED, DIM, DIMFED",
@@ -209,7 +207,6 @@ object Mappings {
                               "10TH, TENTH, 10FED, DEGFED",
                               "11TH, ELEVENTH, 11FED, UNFED, DDEG",
                               "12TH, TWELFTH, 12FED, DEUDDEGFED",
-      
                               "CAREHOME => CARE HOME, CAREHOME, RESIDENTIAL HOME, NURSING HOME, RETIREMENT HOME",
                               "CARE, RESIDENTIAL, NURSING, RETIREMENT",
                               "HMP, HM PRISON",

--- a/batch/src/main/scala/uk/gov/ons/addressindex/utils/Mappings.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/utils/Mappings.scala
@@ -12,7 +12,7 @@ object Mappings {
               "index": {
                   "similarity": {
                       "default": {
-                          "type": "classic"
+                          "type": "BM25"
                       }
                   }
               },
@@ -915,7 +915,7 @@ object Mappings {
               "index": {
                   "similarity": {
                       "default": {
-                          "type": "classic"
+                          "type": "BM25"
                       }
                   }
               },

--- a/batch/src/main/scala/uk/gov/ons/addressindex/utils/SqlHelper.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/utils/SqlHelper.scala
@@ -2,7 +2,7 @@ package uk.gov.ons.addressindex.utils
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.types.{ArrayType, FloatType, LongType, ShortType}
+import org.apache.spark.sql.types.{ArrayType, FloatType, LongType}
 import uk.gov.ons.addressindex.models.{HybridAddressEsDocument, HybridAddressNisraEsDocument, HybridAddressSkinnyEsDocument, HybridAddressSkinnyNisraEsDocument}
 import uk.gov.ons.addressindex.readers.AddressIndexFileReader
 
@@ -177,7 +177,6 @@ object SqlHelper {
         functions.regexp_replace(nisra("altThoroughfare"), "NULL", "").as("altThoroughfare"),
         functions.regexp_replace(nisra("dependentThoroughfare"), "NULL", "").as("dependentThoroughfare"),
         functions.regexp_replace(nisra("locality"), "NULL", "").as("locality"),
-   //     functions.regexp_replace(nisra("townland"), "NULL", "").as("townland"),
         functions.regexp_replace(nisra("udprn"), "NULL", "").as("udprn"),
         functions.regexp_replace(nisra("postTown"), "NULL", "").as("townName"),
         functions.regexp_replace(nisra("postcode"), "NULL", "").as("postcode"),

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocumentSpec.scala
@@ -8,7 +8,7 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
   val format = new java.text.SimpleDateFormat("yyyy-MM-dd")
 
   // Expected Paf values
-  val expectedPafBuildingNumber = 1.toShort
+  val expectedPafBuildingNumber: Short = 1.toShort
   val expectedPafUdprn = 19
   val expectedPafLastUpdateDate = new java.sql.Date(format.parse("2016-02-10").getTime)
   val expectedPafProOrder = 272650L
@@ -36,13 +36,13 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
   val expectedPafWelshThoroughfare = "Welsh2"
   val expectedPafThoroughfare = "Some Street"
   val expectedPafStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
-  val expectedPafRecordIdentifier = 27.toByte
+  val expectedPafRecordIdentifier: Byte = 27.toByte
   val expectedPafAll = "DEPARTMENT CIBO FLAT E COTTAGE 6 1 THROUGHFARE WELSH1 SOME STREET WELSH2 LOCALITY WELSH3 STIXTON WELSH4 LONDON WELSH5 POSTCODE"
   val expectedPafMixed = "Department, Cibo, Flat E, Cottage, PO BOX 6, 1 Throughfare, Some Street, Locality, Stixton, London, POSTCODE"
   val expectedPafWelshMixed = "Department, Cibo, Flat E, Cottage, PO BOX 6, 1 Welsh1, Welsh2, Welsh3, Welsh4, Welsh5, POSTCODE"
 
   // Actual Paf values
-  val actualPafBuildingNumber = 1.toShort
+  val actualPafBuildingNumber: Short = 1.toShort
   val actualPafUdprn = 19
   val actualPafLastUpdateDate = new java.sql.Date(format.parse("2016-02-10").getTime)
   val actualPafProOrder = 272650L
@@ -70,25 +70,25 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
   val actualPafWelshThoroughfare = "WELSH2"
   val actualPafThoroughfare = "SOME STREET"
   val actualPafStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
-  val actualPafRecordIdentifier = 27.toByte
+  val actualPafRecordIdentifier: Byte = 27.toByte
 
   // Expected Nag values
   val expectedNagOrganisation = "Something Else"
   val expectedNagOfficialFlag = "Y"
-  val expectedNagPaoStartNumber = 56.toShort
+  val expectedNagPaoStartNumber: Short = 56.toShort
   val expectedNagPostcodeLocator = "KL8 7HQ"
   val expectedNagSaoEndSuffix = "JJ"
-  val expectedNagSaoStartNumber = 6473.toShort
+  val expectedNagSaoStartNumber: Short = 6473.toShort
   val expectedNagUsrn = 9402538
-  val expectedNagLpiLogicalStatus = 1.toByte
+  val expectedNagLpiLogicalStatus: Byte = 1.toByte
   val expectedNagEasting = 379171.00F
   val expectedNagPaoEndSuffix = "OP"
   val expectedNagStreetDescriptor = "And Another Street Descriptor"
   val expectedNagUprn = 100010971565L
   val expectedNagNorthing = 412816.00F
   val expectedNagLpiKey = "1610L000014429"
-  val expectedNagSaoEndNumber = 6623.toShort
-  val expectedNagPaoEndNumber = 7755.toShort
+  val expectedNagSaoEndNumber: Short = 6623.toShort
+  val expectedNagPaoEndNumber: Short = 7755.toShort
   val expectedNagTownName = "Town B"
   val expectedNagLegalName = "ANOTHER LEGAL NAME"
   val expectedNagSaoStartSuffix = "FF"
@@ -99,13 +99,13 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
   val expectedNagLocality = "Locality Xyz"
   val expectedNagLevel = "UP THERE SOME WHERE"
   val expectedNagParentUprn = 999910971564L
-  val expectedNagMultiOccCount = 0.toShort
-  val expectedNagBlpuLogicalStatus = 1.toByte
-  val expectedNagLocalCustodianCode = 4218.toShort
-  val expectedNagRpc = 1.toByte
-  val expectedNagUsrnMatchIndicator = 1.toByte
+  val expectedNagMultiOccCount: Short = 0.toShort
+  val expectedNagBlpuLogicalStatus: Byte = 1.toByte
+  val expectedNagLocalCustodianCode: Short = 4218.toShort
+  val expectedNagRpc: Byte = 1.toByte
+  val expectedNagUsrnMatchIndicator: Byte = 1.toByte
   val expectedNagLanguage = "ENG"
-  val expectedNagStreetClassification = 8.toByte
+  val expectedNagStreetClassification: Byte = 8.toByte
   val expectedNagAll = "SOMETHING ELSE 6473FF-6623JJ THE BUILDING NAME A TRAINING CENTRE 56HH-7755OP AND ANOTHER STREET DESCRIPTOR LOCALITY XYZ TOWN B KL8 7HQ"
   val expectedNagLpiStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val expectedNagLpiLastUpdateDate = new java.sql.Date(format.parse("2012-04-24").getTime)
@@ -116,20 +116,20 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
   // Actual Nag Values
   val actualNagOrganisation = "SOMETHING ELSE"
   val actualNagOfficialFlag = "Y"
-  val actualNagPaoStartNumber = 56.toShort
+  val actualNagPaoStartNumber: Short = 56.toShort
   val actualNagPostcodeLocator = "KL8 7HQ"
   val actualNagSaoEndSuffix = "JJ"
-  val actualNagSaoStartNumber = 6473.toShort
+  val actualNagSaoStartNumber: Short = 6473.toShort
   val actualNagUsrn = 9402538
-  val actualNagLpiLogicalStatus = 1.toByte
+  val actualNagLpiLogicalStatus: Byte = 1.toByte
   val actualNagEasting = 379171.00F
   val actualNagPaoEndSuffix = "OP"
   val actualNagStreetDescriptor = "AND ANOTHER STREET DESCRIPTOR"
   val actualNagUprn = 100010971565L
   val actualNagNorthing = 412816.00F
   val actualNagLpiKey = "1610L000014429"
-  val actualNagSaoEndNumber = 6623.toShort
-  val actualNagPaoEndNumber = 7755.toShort
+  val actualNagSaoEndNumber: Short = 6623.toShort
+  val actualNagPaoEndNumber: Short = 7755.toShort
   val actualNagTownName = "TOWN B"
   val actualNagLegalName = "ANOTHER LEGAL NAME"
   val actualNagSaoStartSuffix = "FF"
@@ -140,13 +140,13 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
   val actualNagLocality = "LOCALITY XYZ"
   val actualNagLevel = "UP THERE SOME WHERE"
   val actualNagParentUprn = 999910971564L
-  val actualNagMultiOccCount = 0.toShort
-  val actualNagBlpuLogicalStatus = 1.toByte
-  val actualNagLocalCustodianCode = 4218.toShort
-  val actualNagRpc = 1.toByte
-  val actualNagUsrnMatchIndicator = 1.toByte
+  val actualNagMultiOccCount: Short = 0.toShort
+  val actualNagBlpuLogicalStatus: Byte = 1.toByte
+  val actualNagLocalCustodianCode: Short = 4218.toShort
+  val actualNagRpc: Byte = 1.toByte
+  val actualNagUsrnMatchIndicator: Byte = 1.toByte
   val actualNagLanguage = "ENG"
-  val actualNagStreetClassification = 8.toByte
+  val actualNagStreetClassification: Byte = 8.toByte
   val actualNagLpiStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val actualNagLpiLastUpdateDate = new java.sql.Date(format.parse("2012-04-24").getTime)
   val actualNagLpiEndDate = new java.sql.Date(format.parse("2018-01-11").getTime)
@@ -154,7 +154,7 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
   // used by both expected and actual to avoid assertion error
   val nagLocation = Array(-2.3162985F, 4.00F)
 
-  val expectedPaf = Map[String,Any](
+  val expectedPaf: Map[String, Any] = Map[String,Any](
     "buildingNumber" -> expectedPafBuildingNumber,
     "udprn" -> expectedPafUdprn,
     "lastUpdateDate" -> expectedPafLastUpdateDate,
@@ -189,7 +189,7 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
     "mixedWelshPaf" -> expectedPafWelshMixed
   )
 
-  val expectedNag = Map[String,Any](
+  val expectedNag: Map[String, Any] = Map[String,Any](
     "uprn" -> expectedNagUprn,
     "postcodeLocator" -> expectedNagPostcodeLocator,
     "addressBasePostal" -> expectedNagAddressBasePostal,

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocumentSpec.scala
@@ -8,7 +8,7 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val format = new java.text.SimpleDateFormat("yyyy-MM-dd")
 
   // Expected Paf values
-  val expectedPafBuildingNumber = 1.toShort
+  val expectedPafBuildingNumber: Short = 1.toShort
   val expectedPafUdprn = 19
   val expectedPafLastUpdateDate = new java.sql.Date(format.parse("2016-02-10").getTime)
   val expectedPafProOrder = 272650L
@@ -36,13 +36,13 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedPafWelshThoroughfare = "Welsh2"
   val expectedPafThoroughfare = "Some Street"
   val expectedPafStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
-  val expectedPafRecordIdentifier = 27.toByte
+  val expectedPafRecordIdentifier: Byte = 27.toByte
   val expectedPafAll = "DEPARTMENT CIBO FLAT E COTTAGE 6 1 THROUGHFARE WELSH1 SOME STREET WELSH2 LOCALITY WELSH3 STIXTON WELSH4 LONDON WELSH5 POSTCODE"
   val expectedPafMixed = "Department, Cibo, Flat E, Cottage, PO BOX 6, 1 Throughfare, Some Street, Locality, Stixton, London, POSTCODE"
   val expectedPafWelshMixed = "Department, Cibo, Flat E, Cottage, PO BOX 6, 1 Welsh1, Welsh2, Welsh3, Welsh4, Welsh5, POSTCODE"
 
   // Actual Paf values
-  val actualPafBuildingNumber = 1.toShort
+  val actualPafBuildingNumber: Short = 1.toShort
   val actualPafUdprn = 19
   val actualPafLastUpdateDate = new java.sql.Date(format.parse("2016-02-10").getTime)
   val actualPafProOrder = 272650L
@@ -70,25 +70,25 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val actualPafWelshThoroughfare = "WELSH2"
   val actualPafThoroughfare = "SOME STREET"
   val actualPafStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
-  val actualPafRecordIdentifier = 27.toByte
+  val actualPafRecordIdentifier: Byte = 27.toByte
 
   // Expected Nag values
   val expectedNagOrganisation = "Something Else"
   val expectedNagOfficialFlag = "Y"
-  val expectedNagPaoStartNumber = 56.toShort
+  val expectedNagPaoStartNumber: Short = 56.toShort
   val expectedNagPostcodeLocator = "KL8 7HQ"
   val expectedNagSaoEndSuffix = "JJ"
-  val expectedNagSaoStartNumber = 6473.toShort
+  val expectedNagSaoStartNumber: Short = 6473.toShort
   val expectedNagUsrn = 9402538
-  val expectedNagLpiLogicalStatus = 1.toByte
+  val expectedNagLpiLogicalStatus: Byte = 1.toByte
   val expectedNagEasting = 379171.00F
   val expectedNagPaoEndSuffix = "OP"
   val expectedNagStreetDescriptor = "And Another Street Descriptor"
   val expectedNagUprn = 100010971565L
   val expectedNagNorthing = 412816.00F
   val expectedNagLpiKey = "1610L000014429"
-  val expectedNagSaoEndNumber = 6623.toShort
-  val expectedNagPaoEndNumber = 7755.toShort
+  val expectedNagSaoEndNumber: Short = 6623.toShort
+  val expectedNagPaoEndNumber: Short = 7755.toShort
   val expectedNagTownName = "Town B"
   val expectedNagLegalName = "ANOTHER LEGAL NAME"
   val expectedNagSaoStartSuffix = "FF"
@@ -99,13 +99,13 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedNagLocality = "Locality Xyz"
   val expectedNagLevel = "UP THERE SOME WHERE"
   val expectedNagParentUprn = 999910971564L
-  val expectedNagMultiOccCount = 0.toShort
-  val expectedNagBlpuLogicalStatus = 1.toByte
-  val expectedNagLocalCustodianCode = 4218.toShort
-  val expectedNagRpc = 1.toByte
-  val expectedNagUsrnMatchIndicator = 1.toByte
+  val expectedNagMultiOccCount: Short = 0.toShort
+  val expectedNagBlpuLogicalStatus: Byte = 1.toByte
+  val expectedNagLocalCustodianCode: Short = 4218.toShort
+  val expectedNagRpc: Byte = 1.toByte
+  val expectedNagUsrnMatchIndicator: Byte = 1.toByte
   val expectedNagLanguage = "ENG"
-  val expectedNagStreetClassification = 8.toByte
+  val expectedNagStreetClassification: Byte = 8.toByte
   val expectedNagAll = "SOMETHING ELSE 6473FF-6623JJ THE BUILDING NAME A TRAINING CENTRE 56HH-7755OP AND ANOTHER STREET DESCRIPTOR LOCALITY XYZ TOWN B KL8 7HQ"
   val expectedNagLpiStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val expectedNagLpiLastUpdateDate = new java.sql.Date(format.parse("2012-04-24").getTime)
@@ -116,20 +116,20 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   // Actual Nag Values
   val actualNagOrganisation = "SOMETHING ELSE"
   val actualNagOfficialFlag = "Y"
-  val actualNagPaoStartNumber = 56.toShort
+  val actualNagPaoStartNumber: Short = 56.toShort
   val actualNagPostcodeLocator = "KL8 7HQ"
   val actualNagSaoEndSuffix = "JJ"
-  val actualNagSaoStartNumber = 6473.toShort
+  val actualNagSaoStartNumber: Short = 6473.toShort
   val actualNagUsrn = 9402538
-  val actualNagLpiLogicalStatus = 1.toByte
+  val actualNagLpiLogicalStatus: Byte = 1.toByte
   val actualNagEasting = 379171.00F
   val actualNagPaoEndSuffix = "OP"
   val actualNagStreetDescriptor = "AND ANOTHER STREET DESCRIPTOR"
   val actualNagUprn = 100010971565L
   val actualNagNorthing = 412816.00F
   val actualNagLpiKey = "1610L000014429"
-  val actualNagSaoEndNumber = 6623.toShort
-  val actualNagPaoEndNumber = 7755.toShort
+  val actualNagSaoEndNumber: Short = 6623.toShort
+  val actualNagPaoEndNumber: Short = 7755.toShort
   val actualNagTownName = "TOWN B"
   val actualNagLegalName = "ANOTHER LEGAL NAME"
   val actualNagSaoStartSuffix = "FF"
@@ -140,13 +140,13 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val actualNagLocality = "LOCALITY XYZ"
   val actualNagLevel = "UP THERE SOME WHERE"
   val actualNagParentUprn = 999910971564L
-  val actualNagMultiOccCount = 0.toShort
-  val actualNagBlpuLogicalStatus = 1.toByte
-  val actualNagLocalCustodianCode = 4218.toShort
-  val actualNagRpc = 1.toByte
-  val actualNagUsrnMatchIndicator = 1.toByte
+  val actualNagMultiOccCount: Short = 0.toShort
+  val actualNagBlpuLogicalStatus: Byte = 1.toByte
+  val actualNagLocalCustodianCode: Short = 4218.toShort
+  val actualNagRpc: Byte = 1.toByte
+  val actualNagUsrnMatchIndicator: Byte = 1.toByte
   val actualNagLanguage = "ENG"
-  val actualNagStreetClassification = 8.toByte
+  val actualNagStreetClassification: Byte = 8.toByte
   val actualNagLpiStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val actualNagLpiLastUpdateDate = new java.sql.Date(format.parse("2012-04-24").getTime)
   val actualNagLpiEndDate = new java.sql.Date(format.parse("2018-01-11").getTime)
@@ -155,7 +155,7 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedNisraOrganisation = "An Organisation"
   val expectedNisraSubBuildingName = "The Sub Building Name"
   val expectedNisraBuildingName = "The Building Name 1A"
-  val expectedNisraBuildingNumber = null
+  val expectedNisraBuildingNumber: Null = null
   val expectedNisraThoroughfare = "Thoroughfare Road"
   val expectedNisraDependentThoroughfare = "Off Here"
   val expectedNisraAltThoroughfare = "An Alternative Name"
@@ -180,12 +180,12 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedNisraPaoText = "The Building Name"
   val expectedNisraPaoStartNumber = 1
   val expectedNisraPaoStartSuffix = "A"
-  val expectedNisraPaoEndNumber = null
+  val expectedNisraPaoEndNumber: Null = null
   val expectedNisraPaoEndSuffix = ""
   val expectedNisraSaoText = "The Sub Building Name"
-  val expectedNisraSaoStartNumber  = null
+  val expectedNisraSaoStartNumber: Null = null
   val expectedNisraSaoStartSuffix = ""
-  val expectedNisraSaoEndNumber = null
+  val expectedNisraSaoEndNumber: Null = null
   val expectedNisraSaoEndSuffix = ""
   val expectedNisraSecondarySort = "THE BUILDING NAME THE SUB BUILDING NAME AN ORGANISATION"
 
@@ -228,7 +228,7 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   // used by both expected and actual to avoid assertion error
   val nagLocation = Array(-2.3162985F, 4.00F)
 
-  val expectedPaf = Map[String,Any](
+  val expectedPaf: Map[String, Any] = Map[String,Any](
     "buildingNumber" -> expectedPafBuildingNumber,
     "udprn" -> expectedPafUdprn,
     "lastUpdateDate" -> expectedPafLastUpdateDate,
@@ -263,7 +263,7 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
     "mixedWelshPaf" -> expectedPafWelshMixed
   )
 
-  val expectedNag = Map[String,Any](
+  val expectedNag: Map[String, Any] = Map[String,Any](
     "uprn" -> expectedNagUprn,
     "postcodeLocator" -> expectedNagPostcodeLocator,
     "addressBasePostal" -> expectedNagAddressBasePostal,
@@ -306,7 +306,7 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
     "secondarySort" -> expectedNagSecondarySort
   )
 
-  val expectedNisra = Map[String,Any](
+  val expectedNisra: Map[String, Any] = Map[String,Any](
     "uprn" -> expectedNisraUprn,
     "buildingNumber" -> expectedNisraBuildingNumber,
     "easting" -> expectedNisraEasting,

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyEsDocumentSpec.scala
@@ -16,7 +16,7 @@ class HybridAddressSkinnyEsDocumentSpec extends WordSpec with Matchers {
   val expectedPafWelshMixed = "Department, Cibo, Flat E, Cottage, PO BOX 6, 1 Welsh1, Welsh2, Welsh3, Welsh4, Welsh5, POSTCODE"
 
   // Actual Paf Values
-  val actualPafBuildingNumber = 1.toShort
+  val actualPafBuildingNumber: Short = 1.toShort
   val actualPafUdprn = 1
   val actualPafLastUpdateDate = new java.sql.Date(format.parse("2016-02-10").getTime)
   val actualPafProOrder = 272650L
@@ -44,7 +44,7 @@ class HybridAddressSkinnyEsDocumentSpec extends WordSpec with Matchers {
   val actualPafWelshThoroughfare = "WELSH2"
   val actualPafThoroughfare = "SOME STREET"
   val actualPafStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
-  val actualPafRecordIdentifier = 27.toByte
+  val actualPafRecordIdentifier: Byte = 27.toByte
 
   // Expected Nag values
   val expectedNagUprn = 100010971565L
@@ -54,10 +54,10 @@ class HybridAddressSkinnyEsDocumentSpec extends WordSpec with Matchers {
   val expectedNagNorthing = 412816.00F
   val expectedNagParentUprn = 999910971564L
   val expectedNagSaoEndSuffix = "JJ"
-  val expectedNagPaoStartNumber = 56.toShort
+  val expectedNagPaoStartNumber: Short = 56.toShort
   val expectedNagPaoStartSuffix = "HH"
-  val expectedNagSaoStartNumber = 6473.toShort
-  val expectedNagLpiLogicalStatus = 1.toByte
+  val expectedNagSaoStartNumber: Short = 6473.toShort
+  val expectedNagLpiLogicalStatus: Byte = 1.toByte
   val expectedNagStreetDescriptor = "And Another Street Descriptor"
   val expectedNagAll = "SOMETHING ELSE 6473FF-6623JJ THE BUILDING NAME A TRAINING CENTRE 56HH-7755OP AND ANOTHER STREET DESCRIPTOR LOCALITY XYZ TOWN B KL8 7HQ"
   val expectedNagLanguage = "ENG"
@@ -69,20 +69,20 @@ class HybridAddressSkinnyEsDocumentSpec extends WordSpec with Matchers {
   // Actual Nag values
   val actualNagOrganisation = "SOMETHING ELSE"
   val actualNagOfficialFlag = "Y"
-  val actualNagPaoStartNumber = 56.toShort
+  val actualNagPaoStartNumber: Short = 56.toShort
   val actualNagPostcodeLocator = "KL8 7HQ"
   val actualNagSaoEndSuffix = "JJ"
-  val actualNagSaoStartNumber = 6473.toShort
+  val actualNagSaoStartNumber: Short = 6473.toShort
   val actualNagUsrn = 9402538
-  val actualNagLpiLogicalStatus = 1.toByte
+  val actualNagLpiLogicalStatus: Byte = 1.toByte
   val actualNagEasting = 379171.00F
   val actualNagPaoEndSuffix = "OP"
   val actualNagStreetDescriptor = "AND ANOTHER STREET DESCRIPTOR"
   val actualNagUprn = 100010971565L
   val actualNagNorthing = 412816.00F
   val actualNagLpiKey = "1610L000014429"
-  val actualNagSaoEndNumber = 6623.toShort
-  val actualNagPaoEndNumber = 7755.toShort
+  val actualNagSaoEndNumber: Short = 6623.toShort
+  val actualNagPaoEndNumber: Short = 7755.toShort
   val actualNagTownName = "TOWN B"
   val actualNagLegalName = "ANOTHER LEGAL NAME"
   val actualNagSaoStartSuffix = "FF"
@@ -93,13 +93,13 @@ class HybridAddressSkinnyEsDocumentSpec extends WordSpec with Matchers {
   val actualNagLocality = "LOCALITY XYZ"
   val actualNagLevel = "UP THERE SOME WHERE"
   val actualNagParentUprn = 999910971564L
-  val actualNagMultiOccCount = 0.toShort
-  val actualNagBlpuLogicalStatus = 1.toByte
-  val actualNagLocalCustodianCode = 4218.toShort
-  val actualNagRpc = 1.toByte
-  val actualNagUsrnMatchIndicator = 1.toByte
+  val actualNagMultiOccCount: Short = 0.toShort
+  val actualNagBlpuLogicalStatus: Byte = 1.toByte
+  val actualNagLocalCustodianCode: Short = 4218.toShort
+  val actualNagRpc: Byte = 1.toByte
+  val actualNagUsrnMatchIndicator: Byte = 1.toByte
   val actualNagLanguage = "ENG"
-  val actualNagStreetClassification = 8.toByte
+  val actualNagStreetClassification: Byte = 8.toByte
   val actualNagLpiStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val actualNagLpiLastUpdateDate = new java.sql.Date(format.parse("2012-04-24").getTime)
   val actualNagLpiEndDate = new java.sql.Date(format.parse("2018-01-11").getTime)
@@ -107,7 +107,7 @@ class HybridAddressSkinnyEsDocumentSpec extends WordSpec with Matchers {
   // used by both expected and actual to avoid assertion error
   val nagLocation = Array(-2.3162985F, 4.00F)
 
-  val expectedPaf = Map[String,Any](
+  val expectedPaf: Map[String, Any] = Map[String,Any](
     "endDate" -> expectedPafEndDate,
     "uprn" -> expectedPafUprn,
     "startDate" -> expectedPafStartDate,
@@ -116,7 +116,7 @@ class HybridAddressSkinnyEsDocumentSpec extends WordSpec with Matchers {
     "mixedWelshPaf" -> expectedPafWelshMixed
   )
 
-  val expectedNag = Map[String,Any](
+  val expectedNag: Map[String, Any] = Map[String,Any](
     "uprn" -> expectedNagUprn,
     "postcodeLocator" -> expectedNagPostcodeLocator,
     "addressBasePostal" -> expectedNagAddressBasePostal,

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocumentSpec.scala
@@ -16,7 +16,7 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedPafWelshMixed = "Department, Cibo, Flat E, Cottage, PO BOX 6, 1 Welsh1, Welsh2, Welsh3, Welsh4, Welsh5, POSTCODE"
 
   // Actual Paf Values
-  val actualPafBuildingNumber = 1.toShort
+  val actualPafBuildingNumber: Short = 1.toShort
   val actualPafUdprn = 1
   val actualPafLastUpdateDate = new java.sql.Date(format.parse("2016-02-10").getTime)
   val actualPafProOrder = 272650L
@@ -44,7 +44,7 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
   val actualPafWelshThoroughfare = "WELSH2"
   val actualPafThoroughfare = "SOME STREET"
   val actualPafStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
-  val actualPafRecordIdentifier = 27.toByte
+  val actualPafRecordIdentifier: Byte = 27.toByte
 
   // Expected Nag values
   val expectedNagUprn = 100010971565L
@@ -54,10 +54,10 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedNagNorthing = 412816.00F
   val expectedNagParentUprn = 999910971564L
   val expectedNagSaoEndSuffix = "JJ"
-  val expectedNagPaoStartNumber = 56.toShort
+  val expectedNagPaoStartNumber: Short = 56.toShort
   val expectedNagPaoStartSuffix = "HH"
-  val expectedNagSaoStartNumber = 6473.toShort
-  val expectedNagLpiLogicalStatus = 1.toByte
+  val expectedNagSaoStartNumber: Short = 6473.toShort
+  val expectedNagLpiLogicalStatus: Byte = 1.toByte
   val expectedNagStreetDescriptor = "And Another Street Descriptor"
   val expectedNagLanguage = "ENG"
   val expectedNagAll = "SOMETHING ELSE 6473FF-6623JJ THE BUILDING NAME A TRAINING CENTRE 56HH-7755OP AND ANOTHER STREET DESCRIPTOR LOCALITY XYZ TOWN B KL8 7HQ"
@@ -69,20 +69,20 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
   // Actual Nag values
   val actualNagOrganisation = "SOMETHING ELSE"
   val actualNagOfficialFlag = "Y"
-  val actualNagPaoStartNumber = 56.toShort
+  val actualNagPaoStartNumber: Short = 56.toShort
   val actualNagPostcodeLocator = "KL8 7HQ"
   val actualNagSaoEndSuffix = "JJ"
-  val actualNagSaoStartNumber = 6473.toShort
+  val actualNagSaoStartNumber: Short = 6473.toShort
   val actualNagUsrn = 9402538
-  val actualNagLpiLogicalStatus = 1.toByte
+  val actualNagLpiLogicalStatus: Byte = 1.toByte
   val actualNagEasting = 379171.00F
   val actualNagPaoEndSuffix = "OP"
   val actualNagStreetDescriptor = "AND ANOTHER STREET DESCRIPTOR"
   val actualNagUprn = 100010971565L
   val actualNagNorthing = 412816.00F
   val actualNagLpiKey = "1610L000014429"
-  val actualNagSaoEndNumber = 6623.toShort
-  val actualNagPaoEndNumber = 7755.toShort
+  val actualNagSaoEndNumber: Short = 6623.toShort
+  val actualNagPaoEndNumber: Short = 7755.toShort
   val actualNagTownName = "TOWN B"
   val actualNagLegalName = "ANOTHER LEGAL NAME"
   val actualNagSaoStartSuffix = "FF"
@@ -93,13 +93,13 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
   val actualNagLocality = "LOCALITY XYZ"
   val actualNagLevel = "UP THERE SOME WHERE"
   val actualNagParentUprn = 999910971564L
-  val actualNagMultiOccCount = 0.toShort
-  val actualNagBlpuLogicalStatus = 1.toByte
-  val actualNagLocalCustodianCode = 4218.toShort
-  val actualNagRpc = 1.toByte
-  val actualNagUsrnMatchIndicator = 1.toByte
+  val actualNagMultiOccCount: Short = 0.toShort
+  val actualNagBlpuLogicalStatus: Byte = 1.toByte
+  val actualNagLocalCustodianCode: Short = 4218.toShort
+  val actualNagRpc: Byte = 1.toByte
+  val actualNagUsrnMatchIndicator: Byte = 1.toByte
   val actualNagLanguage = "ENG"
-  val actualNagStreetClassification = 8.toByte
+  val actualNagStreetClassification: Byte = 8.toByte
   val actualNagLpiStartDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val actualNagLpiLastUpdateDate = new java.sql.Date(format.parse("2012-04-24").getTime)
   val actualNagLpiEndDate = new java.sql.Date(format.parse("2018-01-11").getTime)
@@ -107,7 +107,7 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
   // NISRA location (shared field to avoid test failure)
   val nisraLocation = Array(-2.3162985F, 4.00F)
 
-  val expectedNisraBuildingNumber = null
+  val expectedNisraBuildingNumber: Null = null
   val expectedNisraPostCode = "AB1 7GH"
   val expectedNisraEasting = 379171.00F
   val expectedNisraNorthing = 412816.00F

--- a/batch/src/test/scala/uk/gov/ons/addressindex/utils/SqlHelperSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/utils/SqlHelperSpec.scala
@@ -194,34 +194,34 @@ class SqlHelperSpec extends WordSpec with Matchers {
       // Then
       result.length shouldBe 5
       val firstLine = result(0)
-      firstLine.getLong(0) shouldBe 1l
+      firstLine.getLong(0) shouldBe 1L
       firstLine.getInt(1) shouldBe 1
-      firstLine.getAs[Array[Long]](2) shouldBe Array(1l)
+      firstLine.getAs[Array[Long]](2) shouldBe Array(1L)
       firstLine.getAs[Array[Long]](3) shouldBe Array()
 
       val secondLine = result(1)
-      secondLine.getLong(0) shouldBe 1l
+      secondLine.getLong(0) shouldBe 1L
       secondLine.getInt(1) shouldBe 2
-      secondLine.getAs[Array[Long]](2) shouldBe Array(2l, 3l, 4l)
-      secondLine.getAs[Array[Long]](3) shouldBe Array(1l, 1l, 1l)
+      secondLine.getAs[Array[Long]](2) shouldBe Array(2L, 3L, 4L)
+      secondLine.getAs[Array[Long]](3) shouldBe Array(1L, 1L, 1L)
 
       val thirdLine = result(2)
-      thirdLine.getLong(0) shouldBe 1l
+      thirdLine.getLong(0) shouldBe 1L
       thirdLine.getInt(1) shouldBe 3
-      thirdLine.getAs[Array[Long]](2) shouldBe Array(5l, 6l, 7l, 8l, 9l)
-      thirdLine.getAs[Array[Long]](3) shouldBe Array(2l, 2l, 2l, 3l, 3l)
+      thirdLine.getAs[Array[Long]](2) shouldBe Array(5L, 6L, 7L, 8L, 9l)
+      thirdLine.getAs[Array[Long]](3) shouldBe Array(2L, 2L, 2L, 3L, 3L)
 
       val forthLine = result(3)
-      forthLine.getLong(0) shouldBe 10l
+      forthLine.getLong(0) shouldBe 10L
       forthLine.getInt(1) shouldBe 1
-      forthLine.getAs[Array[Long]](2) shouldBe Array(10l)
+      forthLine.getAs[Array[Long]](2) shouldBe Array(10L)
       forthLine.getAs[Array[Long]](3) shouldBe Array()
 
       val fifthLine = result(4)
       fifthLine.getLong(0) shouldBe 10l
       fifthLine.getInt(1) shouldBe 2
-      fifthLine.getAs[Array[Long]](2) shouldBe Array(11l, 12l)
-      fifthLine.getAs[Array[Long]](3) shouldBe Array(10l, 10l)
+      fifthLine.getAs[Array[Long]](2) shouldBe Array(11L, 12L)
+      fifthLine.getAs[Array[Long]](3) shouldBe Array(10L, 10L)
     }
 
     "aggregate crossrefs from crossref table" in {
@@ -272,13 +272,6 @@ class SqlHelperSpec extends WordSpec with Matchers {
 
       val nag = SqlHelper.joinCsvs(blpu, classification, lpi, organisation, street, streetDescriptor)
 
-      val nisra = SparkProvider.sqlContext.read
-        .format("com.databricks.spark.csv")
-        .option("header", "true")
-        .option("delimiter", "|")
-        .schema(CSVSchemas.postcodeAddressFileSchema)
-        .load("batch/src/test/resources/txt/nisra/NISRA_test_data.txt")
-
       val expectedFirstRelations = Array(
         Map(
           "level" -> 1,
@@ -327,7 +320,7 @@ class SqlHelperSpec extends WordSpec with Matchers {
       firstResult.classificationCode shouldBe Some("RD")
       firstResult.postcodeOut shouldBe "KL8"
       firstResult.postcodeIn shouldBe "1JQ"
-      firstResult.parentUprn shouldBe 1l
+      firstResult.parentUprn shouldBe 1L
       firstResult.relatives.length shouldBe 3
       firstResult.crossRefs.length shouldBe 2
       firstResult.lpi.size shouldBe 1
@@ -430,7 +423,7 @@ class SqlHelperSpec extends WordSpec with Matchers {
       firstResult.classificationCode shouldBe Some("RD")
       firstResult.postcodeOut shouldBe "KL8"
       firstResult.postcodeIn shouldBe "1JQ"
-      firstResult.parentUprn shouldBe 1l
+      firstResult.parentUprn shouldBe 1L
       firstResult.relatives.length shouldBe 3
       firstResult.crossRefs.length shouldBe 2
       firstResult.lpi.size shouldBe 1
@@ -527,7 +520,7 @@ class SqlHelperSpec extends WordSpec with Matchers {
       firstResult.classificationCode shouldBe Some("RD")
       firstResult.postcodeOut shouldBe "KL8"
       firstResult.postcodeIn shouldBe "1JQ"
-      firstResult.parentUprn shouldBe 1l
+      firstResult.parentUprn shouldBe 1L
       firstResult.relatives.length shouldBe 3
       firstResult.crossRefs.length shouldBe 2
       firstResult.lpi.size shouldBe 1
@@ -640,7 +633,7 @@ class SqlHelperSpec extends WordSpec with Matchers {
       firstResult.classificationCode shouldBe Some("RD")
       firstResult.postcodeOut shouldBe "KL8"
       firstResult.postcodeIn shouldBe "1JQ"
-      firstResult.parentUprn shouldBe 1l
+      firstResult.parentUprn shouldBe 1L
       firstResult.relatives.length shouldBe 3
       firstResult.crossRefs.length shouldBe 2
       firstResult.lpi.size shouldBe 1
@@ -705,7 +698,7 @@ class SqlHelperSpec extends WordSpec with Matchers {
       val firstResult = result(0)
       firstResult.uprn shouldBe 2L
       firstResult.classificationCode shouldBe Some("RD")
-      firstResult.parentUprn shouldBe 1l
+      firstResult.parentUprn shouldBe 1L
       firstResult.lpi.size shouldBe 1
       firstResult.paf shouldBe empty
 
@@ -758,7 +751,7 @@ class SqlHelperSpec extends WordSpec with Matchers {
       val firstResult = result(0)
       firstResult.uprn shouldBe 2L
       firstResult.classificationCode shouldBe Some("RD")
-      firstResult.parentUprn shouldBe 1l
+      firstResult.parentUprn shouldBe 1L
       firstResult.lpi.size shouldBe 1
       firstResult.paf shouldBe empty
 
@@ -805,7 +798,7 @@ class SqlHelperSpec extends WordSpec with Matchers {
       val firstResult = result(0)
       firstResult.uprn shouldBe 2L
       firstResult.classificationCode shouldBe Some("RD")
-      firstResult.parentUprn shouldBe 1l
+      firstResult.parentUprn shouldBe 1L
       firstResult.lpi.size shouldBe 1
       firstResult.paf shouldBe empty
       firstResult.nisra shouldBe empty
@@ -867,7 +860,7 @@ class SqlHelperSpec extends WordSpec with Matchers {
       val firstResult = result(0)
       firstResult.uprn shouldBe 2L
       firstResult.classificationCode shouldBe Some("RD")
-      firstResult.parentUprn shouldBe 1l
+      firstResult.parentUprn shouldBe 1L
       firstResult.lpi.size shouldBe 1
       firstResult.paf shouldBe empty
       firstResult.nisra shouldBe empty


### PR DESCRIPTION
Update to Spark jobs to create ES 7 indexes

Needs BM25 similarity 
Type name not removed for now (      .param("include_type_name", "true") )