### PR TITLE
Fix for commas in formattedaddress1598

### DIFF
--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
@@ -28,8 +28,12 @@ abstract class EsDocument {
     val premsAndThoroughfare = (premises, thoroughfares) match {
       case (sub_build :: build :: Some(number) :: Nil, Some(thorough_first) :: thorough_rest) =>
         sub_build :: build :: poBox :: Some(number + " " + thorough_first) :: thorough_rest
+      case (sub_build :: build :: Some(number) :: Nil, None :: thorough_rest) =>
+        sub_build :: build :: poBox :: Some(number + " " + thorough_rest.headOption.getOrElse(Some("")).getOrElse("")) :: Nil
       case (sub_build :: Some(build@startsWithNumber()) :: None :: Nil, Some(thorough_first) :: thorough_rest) =>
         sub_build :: poBox :: Some(build + " " + thorough_first) :: thorough_rest
+      case (sub_build :: Some(build@startsWithNumber()) :: None :: Nil, None :: thorough_rest) =>
+        sub_build :: poBox :: Some(build + " " + thorough_rest.headOption.getOrElse(Some("")).getOrElse("")) :: Nil
       case (premises, thoroughfares) => (premises :+ poBox) ++ thoroughfares
     }
 

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocument.scala
@@ -1,6 +1,7 @@
 package uk.gov.ons.addressindex.models
 
 import org.apache.spark.sql.Row
+import uk.gov.ons.addressindex.utils.StringUtil.strToOpt
 
 case class HybridAddressNisraEsDocument(uprn: Long,
                                         postcodeIn: String,
@@ -249,18 +250,42 @@ object HybridAddressNisraEsDocument extends EsDocument {
     val trimmedAltThoroughfare = normalize(altThoroughfare)
     val trimmedDependentThoroughfare = normalize(dependentThoroughfare)
 
-    val buildingNumberWithStreetDescription = s"${buildingNumber.toUpperCase} $trimmedDependentThoroughfare"
+    val buildingNumberWithStreetDescription = s"${buildingNumber.toUpperCase} $trimmedThoroughfare"
+    val buildingNameWithStreetDescription = s"${trimmedBuildingName.toUpperCase} $trimmedThoroughfare"
+    val commalessNumberAndStreetPart = if (startsWithNumber.findFirstIn(trimmedBuildingName).isDefined) buildingNameWithStreetDescription else buildingNumberWithStreetDescription
 
     Array(
-      Seq(normalize(organisationName), trimmedSubBuildingName, trimmedBuildingName, buildingNumberWithStreetDescription,
-        trimmedThoroughfare, normalizeTowns(locality), normalizeTowns(townland), normalizeTowns(townName),
+      Seq(normalize(organisationName),
+        trimmedSubBuildingName,
+        if (startsWithNumber.findFirstIn(trimmedBuildingName).isDefined) "" else trimmedBuildingName,
+        commalessNumberAndStreetPart,
+        trimmedDependentThoroughfare,
+        normalizeTowns(locality),
+        normalizeTowns(townland),
+        normalizeTowns(townName),
         postcode.toUpperCase).map(_.trim).filter(_.nonEmpty).mkString(", "),
       if (!altThoroughfare.isEmpty)
-        Seq(normalize(organisationName), trimmedSubBuildingName, trimmedBuildingName, buildingNumberWithStreetDescription,
-          trimmedAltThoroughfare, normalizeTowns(locality), normalizeTowns(townland), normalizeTowns(townName),
+        Seq(normalize(organisationName),
+          trimmedSubBuildingName,
+          trimmedBuildingName,
+          buildingNumber,
+          trimmedAltThoroughfare,
+          trimmedDependentThoroughfare,
+          normalizeTowns(locality),
+          normalizeTowns(townland),
+          normalizeTowns(townName),
           postcode.toUpperCase).map(_.trim).filter(_.nonEmpty).mkString(", ") else "",
-      Seq(organisationName, subBuildingName, buildingName, buildingNumber, dependentThoroughfare, thoroughfare,
-        altThoroughfare, locality, townland, townName, postcode).map(_.trim).filter(_.nonEmpty).mkString(" ")
+      Seq(organisationName,
+        subBuildingName,
+        buildingName,
+        buildingNumber,
+        thoroughfare,
+        dependentThoroughfare,
+        altThoroughfare,
+        locality,
+        townland,
+        townName,
+        postcode).map(_.trim).filter(_.nonEmpty).mkString(" ")
     )
   }
 }

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
@@ -160,18 +160,41 @@ object HybridAddressSkinnyNisraEsDocument extends EsDocument {
     val trimmedAltThoroughfare = normalize(altThoroughfare)
     val trimmedDependentThoroughfare = normalize(dependentThoroughfare)
 
-    val buildingNumberWithStreetDescription = s"${buildingNumber.toUpperCase} $trimmedDependentThoroughfare"
+    val buildingNumberWithStreetDescription = s"${buildingNumber.toUpperCase} $trimmedThoroughfare"
+    val buildingNameWithStreetDescription = s"${trimmedBuildingName.toUpperCase} $trimmedThoroughfare"
+    val commalessNumberAndStreetPart = if (startsWithNumber.findFirstIn(trimmedBuildingName).isDefined) buildingNameWithStreetDescription else buildingNumberWithStreetDescription
 
     Array(
-      Seq(normalize(organisationName), trimmedSubBuildingName, trimmedBuildingName, buildingNumberWithStreetDescription,
-        trimmedThoroughfare, normalizeTowns(locality), normalizeTowns(townland), normalizeTowns(townName),
+      Seq(normalize(organisationName),
+        trimmedSubBuildingName,
+        if (startsWithNumber.findFirstIn(trimmedBuildingName).isDefined) "" else trimmedBuildingName,
+        commalessNumberAndStreetPart,
+        trimmedDependentThoroughfare,
+        normalizeTowns(locality),
+        normalizeTowns(townland),
+        normalizeTowns(townName),
         postcode.toUpperCase).map(_.trim).filter(_.nonEmpty).mkString(", "),
       if (!altThoroughfare.isEmpty)
-        Seq(normalize(organisationName), trimmedSubBuildingName, trimmedBuildingName, buildingNumberWithStreetDescription,
-          trimmedAltThoroughfare, normalizeTowns(locality), normalizeTowns(townland), normalizeTowns(townName),
+        Seq(normalize(organisationName),
+          trimmedSubBuildingName,
+          trimmedBuildingName,
+          buildingNumber,
+          trimmedAltThoroughfare,
+          normalizeTowns(locality),
+          normalizeTowns(townland),
+          normalizeTowns(townName),
           postcode.toUpperCase).map(_.trim).filter(_.nonEmpty).mkString(", ") else "",
-      Seq(organisationName, subBuildingName, buildingName, buildingNumber, dependentThoroughfare, thoroughfare,
-        altThoroughfare, locality, townland, townName, postcode).map(_.trim).filter(_.nonEmpty).mkString(" ")
+      Seq(organisationName,
+        subBuildingName,
+        buildingName,
+        buildingNumber,
+        thoroughfare,
+        dependentThoroughfare,
+        altThoroughfare,
+        locality,
+        townland,
+        townName,
+        postcode).map(_.trim).filter(_.nonEmpty).mkString(" ")
     )
   }
 }

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocument.scala
@@ -180,6 +180,7 @@ object HybridAddressSkinnyNisraEsDocument extends EsDocument {
           trimmedBuildingName,
           buildingNumber,
           trimmedAltThoroughfare,
+          trimmedDependentThoroughfare,
           normalizeTowns(locality),
           normalizeTowns(townland),
           normalizeTowns(townName),

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressEsDocumentSpec.scala
@@ -999,5 +999,98 @@ class HybridAddressEsDocumentSpec extends WordSpec with Matchers {
       // Then
       result shouldBe "6473-6623JJ THE BUILDING NAME 56HH-7755 AND ANOTHER STREET DESCRIPTOR KL8 7HQ"
     }
+
+    "generate concatenated paf (all fields) with commas as recommended by Royal Mail" in {
+
+      // Given
+      val pafBuildingNumber = "1000"
+      val pafDependentThoroughfare = "throughfare"
+      val pafPostcode = "POSTCODE"
+      val pafPoBoxNumber = "6"
+      val pafDependentLocality = "STIXTON"
+      val pafBuildingName = "COTTAGE"
+      val pafOrganisationName = "CIBO"
+      val pafPostTown = "LONDON"
+      val pafDepartmentName = "department"
+      val pafDoubleDependentLocality = "locality"
+      val pafSubBuildingName = "FLAT E"
+      val pafThoroughfare = "SOME_STREET"
+
+      // When
+      val result = HybridAddressEsDocument.generatePaf(
+        poBoxNumber= pafPoBoxNumber, buildingNumber = pafBuildingNumber,
+        dependentThoroughfare = pafDependentThoroughfare, thoroughfare= pafThoroughfare,
+        departmentName = pafDepartmentName, organisationName = pafOrganisationName,
+        subBuildingName = pafSubBuildingName, buildingName = pafBuildingName,
+        doubleDependentLocality = pafDoubleDependentLocality, dependentLocality = pafDependentLocality,
+        postTown = pafPostTown, postcode = pafPostcode
+      )
+
+      // Then
+      result shouldBe List("Department", "Cibo", "Flat E", "Cottage", "PO BOX 6", "1000 Throughfare", "Some_street", "Locality", "Stixton", "London", "POSTCODE")
+
+    }
+
+    "generate concatenated paf (building number no dependent locality) with commas as recommended by Royal Mail" in {
+
+      // Given
+      val pafBuildingNumber = "1000"
+      val pafDependentThoroughfare = ""
+      val pafPostcode = "POSTCODE"
+      val pafPoBoxNumber = ""
+      val pafDependentLocality = "SIXTON"
+      val pafBuildingName = ""
+      val pafOrganisationName = ""
+      val pafPostTown = "LONDON"
+      val pafDepartmentName = ""
+      val pafDoubleDependentLocality = ""
+      val pafSubBuildingName = ""
+      val pafThoroughfare = "SOME_STREET"
+
+      // When
+      val result = HybridAddressEsDocument.generatePaf(
+        poBoxNumber= pafPoBoxNumber, buildingNumber = pafBuildingNumber,
+        dependentThoroughfare = pafDependentThoroughfare, thoroughfare= pafThoroughfare,
+        departmentName = pafDepartmentName, organisationName = pafOrganisationName,
+        subBuildingName = pafSubBuildingName, buildingName = pafBuildingName,
+        doubleDependentLocality = pafDoubleDependentLocality, dependentLocality = pafDependentLocality,
+        postTown = pafPostTown, postcode = pafPostcode
+      )
+
+      // Then
+      result shouldBe List("1000 Some_street", "Sixton", "London", "POSTCODE")
+
+    }
+
+    "generate concatenated paf (building name containing number no dependent locality) with commas as recommended by Royal Mail" in {
+
+      // Given
+      val pafBuildingNumber = ""
+      val pafDependentThoroughfare = ""
+      val pafPostcode = "POSTCODE"
+      val pafPoBoxNumber = ""
+      val pafDependentLocality = "SIXTON"
+      val pafBuildingName = "22B"
+      val pafOrganisationName = ""
+      val pafPostTown = "LONDON"
+      val pafDepartmentName = ""
+      val pafDoubleDependentLocality = ""
+      val pafSubBuildingName = ""
+      val pafThoroughfare = "BAKER STREET"
+
+      // When
+      val result = HybridAddressEsDocument.generatePaf(
+        poBoxNumber= pafPoBoxNumber, buildingNumber = pafBuildingNumber,
+        dependentThoroughfare = pafDependentThoroughfare, thoroughfare= pafThoroughfare,
+        departmentName = pafDepartmentName, organisationName = pafOrganisationName,
+        subBuildingName = pafSubBuildingName, buildingName = pafBuildingName,
+        doubleDependentLocality = pafDoubleDependentLocality, dependentLocality = pafDependentLocality,
+        postTown = pafPostTown, postcode = pafPostcode
+      )
+
+      // Then
+      result shouldBe List("22B Baker Street", "Sixton", "London", "POSTCODE")
+
+    }
   }
 }

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocumentSpec.scala
@@ -170,9 +170,9 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedNisraAddressStatus = "APPROVED"
   val expectedNisraBuildingStatus = "WONKY"
   val expectedNisraClassificationCode = "DO_APART"
-  val expectedNisraMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, Thoroughfare Road, A Locality Xyz, Little Town, AB1 7GH"
-  val expectedNisraAltMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, An Alternative Name, A Locality Xyz, Little Town, AB1 7GH"
-  val expectedNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A OFF HERE THOROUGHFARE ROAD AN ALTERNATIVE NAME A LOCALITY XYZ LITTLE TOWN AB1 7GH"
+  val expectedNisraMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Thoroughfare Road, Off Here, A Locality Xyz, Little Town, AB1 7GH"
+  val expectedNisraAltMixed = "An Organisation, The Sub Building Name, The Building Name, 1A, An Alternative Name, Off Here, A Locality Xyz, Little Town, AB1 7GH"
+  val expectedNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A THOROUGHFARE ROAD OFF HERE AN ALTERNATIVE NAME A LOCALITY XYZ LITTLE TOWN AB1 7GH"
   val expectedNisraCreationDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val expectedNisraCommencementDate = new java.sql.Date(format.parse("2012-04-24").getTime)
   val expectedNisraArchivedDate = new java.sql.Date(format.parse("2018-01-11").getTime)
@@ -208,11 +208,11 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val actualNisraAddressStatus = "APPROVED"
   val actualNisraBuildingStatus = "WONKY"
   val actualNisraClassificationCode = "DO_APART"
-  val actualNisraMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
-  val actualNisraAltMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, An Alternative Name, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
-  val actualNisraBuildingNumMixed = "1, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
-  val actualNisraBuildingNameMixed = "1A, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
-  val actualNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A OFF HERE THOROUGHFARE ROAD AN ALTERNATIVE NAME A LOCALITY XYZ BIG TOWNLAND LITTLE TOWN AB1 7GH"
+  val actualNisraMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Thoroughfare Road, Off Here, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraAltMixed = "An Organisation, The Sub Building Name, The Building Name, 1A, An Alternative Name, Off Here, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraBuildingNumMixed = "1 Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraBuildingNameMixed = "1A Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A THOROUGHFARE ROAD OFF HERE AN ALTERNATIVE NAME A LOCALITY XYZ BIG TOWNLAND LITTLE TOWN AB1 7GH"
   val actualNisraCreationDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val actualNisraCommencementDate = new java.sql.Date(format.parse("2012-04-24").getTime)
   val actualNisraArchivedDate = new java.sql.Date(format.parse("2018-01-11").getTime)
@@ -1071,7 +1071,7 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
         actualNisraTownland, actualNisraTown, actualNisraPostCode)
 
       val expected = actualNisraMixed
-      val expectedNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A OFF HERE THOROUGHFARE ROAD A LOCALITY XYZ BIG TOWNLAND LITTLE TOWN AB1 7GH"
+      val expectedNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A THOROUGHFARE ROAD OFF HERE A LOCALITY XYZ BIG TOWNLAND LITTLE TOWN AB1 7GH"
 
       // Then
       result(0) shouldBe expected

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressNisraEsDocumentSpec.scala
@@ -210,6 +210,8 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
   val actualNisraClassificationCode = "DO_APART"
   val actualNisraMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
   val actualNisraAltMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, An Alternative Name, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraBuildingNumMixed = "1, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraBuildingNameMixed = "1A, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
   val actualNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A OFF HERE THOROUGHFARE ROAD AN ALTERNATIVE NAME A LOCALITY XYZ BIG TOWNLAND LITTLE TOWN AB1 7GH"
   val actualNisraCreationDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val actualNisraCommencementDate = new java.sql.Date(format.parse("2012-04-24").getTime)
@@ -1091,5 +1093,51 @@ class HybridAddressNisraEsDocumentSpec extends WordSpec with Matchers {
       result(1) shouldBe expected
       result(2) shouldBe expectedNisraAll
     }
+
+    "create NISRA with expected formatted address (number and thoroughfare)" in {
+
+      // When
+      val result = HybridAddressNisraEsDocument.generateFormattedNisraAddresses(
+        "",
+       "",
+        "",
+        "1",
+        actualNisraThoroughfare,
+        "",
+        "",
+        actualNisraLocality,
+        actualNisraTownland,
+        actualNisraTown,
+        actualNisraPostCode)
+
+      val expected =  actualNisraBuildingNumMixed
+
+      // Then
+      result(0) shouldBe expected
+    }
+
+
+    "create NISRA with expected formatted address (part-numeric building and thoroughfare)" in {
+
+      // Also tests nisraAll
+      // When
+      val result = HybridAddressNisraEsDocument.generateFormattedNisraAddresses(
+       "",
+        "",
+        "1A",
+        "",
+        actualNisraThoroughfare,
+        "",
+        "",
+        actualNisraLocality,
+        actualNisraTownland,
+        actualNisraTown,
+        actualNisraPostCode)
+
+      val expected =  actualNisraBuildingNameMixed
+
+      // Then
+      result(0) shouldBe expected
+   }
   }
 }

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocumentSpec.scala
@@ -175,6 +175,8 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
   val actualNisraClassificationCode = "DO_APART"
   val actualNisraMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
   val actualNisraAltMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, An Alternative Name, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraBuildingNumMixed = "1, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraBuildingNameMixed = "1A, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
   val actualNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A OFF HERE THOROUGHFARE ROAD AN ALTERNATIVE NAME A LOCALITY XYZ BIG TOWNLAND LITTLE TOWN AB1 7GH"
   val actualNisraCreationDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val actualNisraCommencementDate = new java.sql.Date(format.parse("2012-04-24").getTime)
@@ -377,6 +379,52 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
       // Then
       result(1) shouldBe expected
       result(2) shouldBe expectedAll
+    }
+
+    "create NISRA with expected formatted address (number and thoroughfare)" in {
+
+      // When
+      val result = HybridAddressNisraEsDocument.generateFormattedNisraAddresses(
+        "",
+        "",
+        "",
+        "1",
+        actualNisraThoroughfare,
+        "",
+        "",
+        actualNisraLocality,
+        actualNisraTownland,
+        actualNisraTown,
+        actualNisraPostCode)
+
+      val expected =  actualNisraBuildingNumMixed
+
+      // Then
+      result(0) shouldBe expected
+    }
+
+
+    "create NISRA with expected formatted address (part-numeric building and thoroughfare)" in {
+
+      // Also tests nisraAll
+      // When
+      val result = HybridAddressNisraEsDocument.generateFormattedNisraAddresses(
+        "",
+        "",
+        "1A",
+        "",
+        actualNisraThoroughfare,
+        "",
+        "",
+        actualNisraLocality,
+        actualNisraTownland,
+        actualNisraTown,
+        actualNisraPostCode)
+
+      val expected =  actualNisraBuildingNameMixed
+
+      // Then
+      result(0) shouldBe expected
     }
   }
 }

--- a/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocumentSpec.scala
+++ b/batch/src/test/scala/uk/gov/ons/addressindex/models/HybridAddressSkinnyNisraEsDocumentSpec.scala
@@ -114,9 +114,9 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
   val expectedNisraUprn = 100010977866L
   val expectedNisraPaoStartNumber = 1
   val expectedNisraSaoStartNumber = 1
-  val expectedNisraMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, Thoroughfare Road, A Locality Xyz, Little Town, AB1 7GH"
-  val expectedNisraAltMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, An Alternative Name, A Locality Xyz, Little Town, AB1 7GH"
-  val expectedNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A OFF HERE THOROUGHFARE ROAD AN ALTERNATIVE NAME A LOCALITY XYZ LITTLE TOWN AB1 7GH"
+  val expectedNisraMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Thoroughfare Road, Off Here, A Locality Xyz, Little Town, AB1 7GH"
+  val expectedNisraAltMixed = "An Organisation, The Sub Building Name, The Building Name, 1A, An Alternative Name, Off Here, A Locality Xyz, Little Town, AB1 7GH"
+  val expectedNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A THOROUGHFARE ROAD OFF HERE AN ALTERNATIVE NAME A LOCALITY XYZ LITTLE TOWN AB1 7GH"
   val expectedNisraAddressStatus = "APPROVED"
   val expectedNisraClassificationCode = "DO_APART"
   val expectedNisraSecondarySort = "THE BUILDING NAME 0001 THE SUB BUILDING NAME AN ORGANISATION"
@@ -173,11 +173,11 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
   val actualNisraAddressStatus = "APPROVED"
   val actualNisraBuildingStatus = "WONKY"
   val actualNisraClassificationCode = "DO_APART"
-  val actualNisraMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
-  val actualNisraAltMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Off Here, An Alternative Name, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
-  val actualNisraBuildingNumMixed = "1, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
-  val actualNisraBuildingNameMixed = "1A, Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
-  val actualNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A OFF HERE THOROUGHFARE ROAD AN ALTERNATIVE NAME A LOCALITY XYZ BIG TOWNLAND LITTLE TOWN AB1 7GH"
+  val actualNisraMixed = "An Organisation, The Sub Building Name, The Building Name, 1A Thoroughfare Road, Off Here, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraAltMixed = "An Organisation, The Sub Building Name, The Building Name, 1A, An Alternative Name, Off Here, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraBuildingNumMixed = "1 Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraBuildingNameMixed = "1A Thoroughfare Road, A Locality Xyz, Big Townland, Little Town, AB1 7GH"
+  val actualNisraAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A THOROUGHFARE ROAD OFF HERE AN ALTERNATIVE NAME A LOCALITY XYZ BIG TOWNLAND LITTLE TOWN AB1 7GH"
   val actualNisraCreationDate = new java.sql.Date(format.parse("2012-04-23").getTime)
   val actualNisraCommencementDate = new java.sql.Date(format.parse("2012-04-24").getTime)
   val actualNisraArchivedDate = new java.sql.Date(format.parse("2018-01-11").getTime)
@@ -358,7 +358,7 @@ class HybridAddressSkinnyNisraEsDocumentSpec extends WordSpec with Matchers {
         "", actualNisraTown, actualNisraPostCode)
 
       val expected = expectedNisraMixed
-      val expectedAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A OFF HERE THOROUGHFARE ROAD A LOCALITY XYZ LITTLE TOWN AB1 7GH"
+      val expectedAll = "AN ORGANISATION THE SUB BUILDING NAME THE BUILDING NAME 1A THOROUGHFARE ROAD OFF HERE A LOCALITY XYZ LITTLE TOWN AB1 7GH"
 
       // Then
       result(0) shouldBe expected


### PR DESCRIPTION
This fixes the cases where the PAF address has a comma (note that we actually don't have to follow Royal Mail guidelines, we could decide to keep the commas between every address part, but if we do needs to be consistent), and also for NISRA.

Spotted an additional problems with NISRA where the dependentthoroughfare and thoroughfare were the wrong way round.

Has been tested on ES7. Authorization changes needed for this, in a separate PR.