### PR TITLE
Config changes to Spark job to make it work on new Cloudera

### DIFF
--- a/batch/build.sbt
+++ b/batch/build.sbt
@@ -7,9 +7,9 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  "org.apache.spark" %% "spark-core" % "2.3.2",
-  "org.apache.spark" %% "spark-sql" % "2.3.2",
-  "org.apache.spark" %% "spark-hive" % "2.3.2",
+  "org.apache.spark" %% "spark-core" % "2.4.0",
+  "org.apache.spark" %% "spark-sql" % "2.4.0",
+  "org.apache.spark" %% "spark-hive" % "2.4.0",
   "com.databricks" %% "spark-csv" % "1.5.0",
   "com.typesafe" % "config" % "1.3.3",
   "org.elasticsearch" %% "elasticsearch-spark-20" % "7.3.1"  excludeAll ExclusionRule(organization = "javax.servlet"),

--- a/batch/build.sbt
+++ b/batch/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "2.4.0" % "provided",
   "org.apache.spark" %% "spark-sql" % "2.4.0" % "provided",
   "org.apache.spark" %% "spark-hive" % "2.4.0" % "provided",
-  "commons-httpclient" %% "commons-httpclient" % "3.1",
+  "commons-httpclient" % "commons-httpclient" % "3.1",
   "com.databricks" %% "spark-csv" % "1.5.0",
   "com.typesafe" % "config" % "1.3.3",
   "org.elasticsearch" %% "elasticsearch-spark-20" % "7.3.1"  excludeAll ExclusionRule(organization = "javax.servlet"),

--- a/batch/build.sbt
+++ b/batch/build.sbt
@@ -10,6 +10,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "2.4.0" % "provided",
   "org.apache.spark" %% "spark-sql" % "2.4.0" % "provided",
   "org.apache.spark" %% "spark-hive" % "2.4.0" % "provided",
+  "commons-httpclient" %% "commons-httpclient" % "3.1",
   "com.databricks" %% "spark-csv" % "1.5.0",
   "com.typesafe" % "config" % "1.3.3",
   "org.elasticsearch" %% "elasticsearch-spark-20" % "7.3.1"  excludeAll ExclusionRule(organization = "javax.servlet"),

--- a/batch/build.sbt
+++ b/batch/build.sbt
@@ -7,9 +7,9 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-compiler" % scalaVersion.value,
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  "org.apache.spark" %% "spark-core" % "2.4.0",
-  "org.apache.spark" %% "spark-sql" % "2.4.0",
-  "org.apache.spark" %% "spark-hive" % "2.4.0",
+  "org.apache.spark" %% "spark-core" % "2.4.0" % "provided",
+  "org.apache.spark" %% "spark-sql" % "2.4.0" % "provided",
+  "org.apache.spark" %% "spark-hive" % "2.4.0" % "provided",
   "com.databricks" %% "spark-csv" % "1.5.0",
   "com.typesafe" % "config" % "1.3.3",
   "org.elasticsearch" %% "elasticsearch-spark-20" % "7.3.1"  excludeAll ExclusionRule(organization = "javax.servlet"),

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
@@ -7,8 +7,14 @@ import uk.gov.ons.addressindex.utils.StringUtil.strToOpt
 import scala.io.{BufferedSource, Source}
 import scala.util.Try
 import scala.util.matching.Regex
+import scala.io.Codec
+import java.nio.charset.CodingErrorAction
 
 abstract class EsDocument {
+
+  implicit val codec = Codec("UTF-8")
+  codec.onMalformedInput(CodingErrorAction.REPLACE)
+  codec.onUnmappableCharacter(CodingErrorAction.REPLACE)
 
   def rowToLpi(row: Row): Map[String, Any]
 
@@ -252,7 +258,7 @@ abstract class EsDocument {
     val currentDirectory = new java.io.File(".").getCanonicalPath
     // `Source.fromFile` needs an absolute path to the file, and current directory depends on where sbt was lauched
     // `getResource` may return null, that's why we wrap it into an `Option`
-    Option(getClass.getResource(path)).map(Source.fromURL).getOrElse(Source.fromFile((currentDirectory + path),"UTF-8"))
+    Option(getClass.getResource(path)).map(Source.fromURL).getOrElse(Source.fromFile(currentDirectory + path))
   }
 
   def toShort(s: String): Option[Short] = {

--- a/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/models/EsDocument.scala
@@ -252,7 +252,7 @@ abstract class EsDocument {
     val currentDirectory = new java.io.File(".").getCanonicalPath
     // `Source.fromFile` needs an absolute path to the file, and current directory depends on where sbt was lauched
     // `getResource` may return null, that's why we wrap it into an `Option`
-    Option(getClass.getResource(path)).map(Source.fromURL).getOrElse(Source.fromFile(currentDirectory + path))
+    Option(getClass.getResource(path)).map(Source.fromURL).getOrElse(Source.fromFile((currentDirectory + path),"UTF-8"))
   }
 
   def toShort(s: String): Option[Short] = {

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val commonSettings = Seq(
   version := "0.0.1",
   organization := "uk.gov.ons",
-  scalaVersion := "2.11.8",
+  scalaVersion := "2.11.12",
   test in assembly := {}
 )
 


### PR DESCRIPTION
FWMT-2365
Upgrade Spark to 2.4.0
Scala to 2.11.12
Cloudera 6.3.3. uses Hadoop 3.0.0 but 2.6.5 jars are bundled by default, causing a mismatch, Solution chosen was to create a thin jar using %provided  rather than trying to bundle the 3.0 jars.
Code added to force used of UTF-8 codec to avoid java.nio.charset.MalformedException
Job is now working, slightly different commands to run, Confluence page updated.