### PR TITLE
Refactor build to allow for different libraries for local and remote

### DIFF
--- a/batch/build.sbt
+++ b/batch/build.sbt
@@ -1,16 +1,27 @@
 resolvers ++= Seq(
   // allows us to include spark packages
   "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/",
-  "conjars" at "http://conjars.org/repo"
+  "conjars" at "https://conjars.org/repo"
 )
 
-libraryDependencies ++= Seq(
-  "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+val localTarget: Boolean = false
+// set to true when testing locally, false for deployment to Cloudera
+// reload all sbt projects to clear ivy cache
+
+val localDeps = Seq(
+  "org.apache.spark" %% "spark-core" % "2.4.0",
+  "org.apache.spark" %% "spark-sql" % "2.4.0",
+  "org.apache.spark" %% "spark-hive" % "2.4.0"
+)
+
+val clouderaDeps = Seq(
   "org.apache.spark" %% "spark-core" % "2.4.0" % "provided",
   "org.apache.spark" %% "spark-sql" % "2.4.0" % "provided",
   "org.apache.spark" %% "spark-hive" % "2.4.0" % "provided",
-  "commons-httpclient" % "commons-httpclient" % "3.1",
+  "commons-httpclient" % "commons-httpclient" % "3.1"
+)
+
+val otherDeps = Seq(
   "com.databricks" %% "spark-csv" % "1.5.0",
   "com.typesafe" % "config" % "1.3.3",
   "org.elasticsearch" %% "elasticsearch-spark-20" % "7.3.1"  excludeAll ExclusionRule(organization = "javax.servlet"),
@@ -18,8 +29,16 @@ libraryDependencies ++= Seq(
   "org.rogach" %% "scallop" % "3.1.5",
   "org.scalaj" %% "scalaj-http" % "2.4.1",
   "com.crealytics" %% "spark-excel" % "0.10.2"
-
 )
+
+if (localTarget) libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value
+) ++ localDeps ++ otherDeps
+else libraryDependencies ++= Seq(
+  "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value
+) ++ clouderaDeps ++ otherDeps
 
 dependencyOverrides += "commons-codec" % "commons-codec" % "1.11"
 

--- a/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/Main.scala
@@ -44,6 +44,7 @@ For usage see below:
   val authHeader = s"Basic ${AuthUtil.encodeCredentials(username, password)}"
 
  //  each run of this application has a unique index name
+ // comment out for local test - start
     val indexName = generateIndexName(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
     val url = s"http://$nodes:$port/$indexName"
 
@@ -54,11 +55,14 @@ For usage see below:
     saveHybridAddresses(historical = !opts.hybridNoHist(), skinny = opts.skinny(), nisra = opts.nisra())
     postLoad(indexName)
   } else opts.printHelp()
+  // comment out for local test - end
 
+// uncomment for local test - start
 //      val indexName = generateIndexName(historical = false, skinny = false, nisra = false)
 //      val url = s"http://$nodes:$port/$indexName"
 //      postMapping(indexName, skinny = true)
 //      saveHybridAddresses(historical = true, skinny = true, nisra = false)
+// uncomment for local test - end
 
   private def generateIndexName(historical: Boolean = true, skinny: Boolean = false, nisra: Boolean = false): String =
     AddressIndexFileReader.generateIndexNameFromFileName(historical, skinny, nisra)

--- a/batch/src/main/scala/uk/gov/ons/addressindex/readers/AddressIndexFileReader.scala
+++ b/batch/src/main/scala/uk/gov/ons/addressindex/readers/AddressIndexFileReader.scala
@@ -106,6 +106,7 @@ object AddressIndexFileReader {
       .format("com.databricks.spark.csv")
       .schema(schema)
       .option("header", "true")
+      .option("mode", "PERMISSIVE")
       .load(resolveAbsolutePath(path))
 
   private def readTxt(path: String, schema: StructType): DataFrame =
@@ -114,6 +115,7 @@ object AddressIndexFileReader {
       .schema(schema)
       .option("header", "true")
       .option("delimiter", "|")
+      .option("mode", "PERMISSIVE")
       .load(resolveAbsolutePath(path))
 
   private def resolveAbsolutePath(path: String) = {


### PR DESCRIPTION
Add flag to build.sbt for local (notes on Confluence updated)
Also looked at warning about headings - capitalization is not consistent on input files, set mode to PERMISSIVE and will be able to see in build logs if the names only differ by capitals and underscore (in which case not a problem).